### PR TITLE
Embed license file in nuget package.

### DIFF
--- a/src/Winton.Extensions.Serialization.Json/Winton.Extensions.Serialization.Json.csproj
+++ b/src/Winton.Extensions.Serialization.Json/Winton.Extensions.Serialization.Json.csproj
@@ -9,7 +9,7 @@
     <NoWarn>$(NoWarn);SA1413</NoWarn>
     <PackageId>Winton.Extensions.Serialization.Json</PackageId>
     <PackageIconUrl>https://raw.githubusercontent.com/wintoncode/Winton.Extensions.Serialization.Json/master/icon.jpg</PackageIconUrl>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/wintoncode/Winton.Extensions.Serialization.Json/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/wintoncode/Winton.Extensions.Serialization.Json</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
     <PackageTags>Winton, Extensions, Serialization, Json, Library</PackageTags>
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <AdditionalFiles Include="../../stylecop.json" />
+    <None Include="../../LICENSE" Pack="true" PackagePath=""/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
NuGet are [deprecating license URLs](https://github.com/NuGet/Announcements/issues/32) in favour of either embedding the license file in the package or using a SPDX license expression. The relevant updates to the project metadata formats are described [here](https://github.com/NuGet/Home/wiki/Packaging-License-within-the-nupkg#project-properties).